### PR TITLE
Remove PGLib form the direct dependencies

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[PGLib_opf]
+git-tree-sha1 = "0e8968a89b6ad43910a8eda4ec30656add35cf91"
+
+    [[PGLib_opf.download]]
+    sha256 = "f1421ce22f0a7b9de8a8b2111776b496348220192ad24aace392c3bf608706c2"
+    url = "https://github.com/power-grid-lib/pglib-opf/archive/refs/tags/v23.07.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ authors = ["Archim Jhunjhunwala <archimj@mit.edu>"]
 version = "0.1.0"
 
 [deps]
-PGLib = "07a8691f-3d11-4330-951b-3c50f98338be"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
-PGLib = "0.2.1"
+Artifacts = "1.11.0"
 julia = "1.9"

--- a/src/ExaPowerIO.jl
+++ b/src/ExaPowerIO.jl
@@ -1,6 +1,8 @@
 module ExaPowerIO
 
-import PGLib
+using Artifacts
+
+const PGLib_opf = joinpath(artifact"PGLib_opf","pglib-opf-23.07")
 
 include("parser.jl")
 
@@ -28,15 +30,11 @@ function parse_pglib(
     dataset_query :: String;
     out_type=PowerData
 ) :: Union{NamedTuple, PowerData{T}} where {T<:Real, V<:AbstractVector}
-    pglib_matches = PGLib.find_pglib_case(dataset_query)
-    dataset = if length(pglib_matches) == 0
+    pglib_file = joinpath(PGLib_opf, dataset_query)
+    if !isfile(pglib_file)
         throw(error("No matches found for pglib dataset: $dataset_query"))
-    elseif length(pglib_matches) > 1
-        throw(error("Ambiguity when specifying dataset $dataset_query. Possible matches: $pglib_matches"))
-    else
-        pglib_matches[1]
     end
-    parse_file(T, V, joinpath(PGLib.PGLib_opf, dataset); out_type)
+    parse_file(T, V, pglib_file; out_type)
 end
 
 convert(::Type{T}, data::PowerData) where T<:PowerData = data


### PR DESCRIPTION
I think it would be better if we keep the dependencies minimal. If we remove PGLib from the deps, we do not depend on PowerModels/JuMP anymore.